### PR TITLE
Add a blacklist for randomCharFromSetCensorStrategy

### DIFF
--- a/src/censor/BuiltinStrategies.ts
+++ b/src/censor/BuiltinStrategies.ts
@@ -87,7 +87,7 @@ export function asteriskCensorStrategy() {
  * @returns A [[TextCensorStrategy]] for use with the [[TextCensor]].
  */
 export function grawlixCensorStrategy() {
-	return randomCharFromSetCensorStrategy('%@$&*');
+	return randomCharFromSetCensorStrategy('%@$&*', ['@$$']);
 }
 
 /**
@@ -152,12 +152,15 @@ export function fixedCharCensorStrategy(char: string): TextCensorStrategy {
  * be constructed. Must not be empty.
  * @returns A [[TextCensorStrategy]] for use with the [[TextCensor]].
  */
-export function randomCharFromSetCensorStrategy(charset: string): TextCensorStrategy {
+export function randomCharFromSetCensorStrategy(charset: string, blacklist?: string[]): TextCensorStrategy {
 	const chars = [...charset];
 	if (chars.length === 0) throw new Error('The character set passed must not be empty.');
 	return (ctx: CensorContext) => {
-		let censored = '';
-		for (let i = 0; i < ctx.matchLength; i++) censored += chars[Math.floor(Math.random() * chars.length)];
-		return censored;
+		for (;;) {
+			let censored = '';
+			for (let i = 0; i < ctx.matchLength; i++) censored += chars[Math.floor(Math.random() * chars.length)];
+			if (blacklist !== undefined && blacklist.includes(censored)) continue;
+			return censored;
+		}
 	};
 }

--- a/test/censor/BuiltinStrategies.test.ts
+++ b/test/censor/BuiltinStrategies.test.ts
@@ -144,4 +144,11 @@ describe('randomCharFromSetCensorStrategy()', () => {
 		const strategy = randomCharFromSetCensorStrategy(charset);
 		expect([...strategy({ ...partialCtx, matchLength: 5 })].every((c) => charset.includes(c))).toBeTruthy();
 	});
+
+	it('should respect blacklist', () => {
+		const strategy = randomCharFromSetCensorStrategy('@$', ['@$$']);
+		for (let i = 0; i < 100; i++) {
+			expect(strategy({ ...partialCtx, matchLength: 3 })).not.toBe('@$$');
+		}
+	});
 });


### PR DESCRIPTION
Fixes #82

**Type of change:**

- [ ] Refactor
- [ ] Performance improvement
- [ ] New feature
- [x] Bug fix
- [ ] Other (please describe):

**Please describe the changes this PR makes and why it should be merged:**

As suggested in #82, make randomCharFromSetCensorStrategy generate a new replacement string if it generated a bad word.

**Status:**

- [x] I've added/modified unit tests relevant to my change / not needed
- [ ] This PR contains breaking changes
- [ ] This PR doesn't include changes to the code
