### PR TITLE
Add missing export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export * from './pattern/Pattern';
 
 export * from './preset/english';
 
+export * from './transformer/Transformers';
 export * from './transformer/collapse-duplicates';
 export * from './transformer/remap-characters';
 export * from './transformer/resolve-confusables';


### PR DESCRIPTION
Without this it's not possible to create custom transformers like shown in the guide: https://github.com/jo3-l/obscenity/blob/main/docs/guide/transformers.md

**Type of change:**

- [ ] Refactor
- [ ] Performance improvement
- [ ] New feature
- [x] Bug fix
- [ ] Other (please describe):
